### PR TITLE
Quote paths passed to Start-Process, tweak Get-Command & Start-Process syntax

### DIFF
--- a/ReflectCmdlet/ReflectCmdlet.psm1
+++ b/ReflectCmdlet/ReflectCmdlet.psm1
@@ -79,16 +79,16 @@ function Get-CommandSource {
         }
         $type = $commandInfo.ImplementingType.FullName
 
-        if (($Decompiler -eq [Decompiler]::dnSpy -or !$Decompiler) -and (Get-Command dnSpy -ErrorAction SilentlyContinue)) {
-            Start-Process -FilePath dnSpy -ArgumentList "$assembly --select T:$type"
-        } elseif (($Decompiler -eq [Decompiler]::ILSpy -or !$Decompiler) -and (Get-Command ILSpy -ErrorAction SilentlyContinue)) {
-            Start-Process -FilePath ILSpy -ArgumentList "$assembly /navigateTo:T:$type"
-        } elseif (($Decompiler -eq [Decompiler]::dotPeek -or !$Decompiler) -and (Get-Command dotPeek32 -ErrorAction SilentlyContinue)) {
-            dotPeek32 /select=$assembly!$type
-        } elseif (($Decompiler -eq [Decompiler]::JustDecompile -or !$Decompiler) -and (Get-Command JustDecompile -ErrorAction SilentlyContinue)) {
-            Start-Process -FilePath JustDecompile -ArgumentList "/target:$assembly"
-        } elseif (($Decompiler -eq [Decompiler]::Reflector -or !$Decompiler) -and (Get-Command reflector -ErrorAction SilentlyContinue)) {
-            Start-Process -FilePath reflector -ArgumentList "/select:$type $assembly"
+        if (($Decompiler -eq [Decompiler]::dnSpy -or !$Decompiler) -and (Get-Command dnSpy -ErrorAction Ignore)) {
+            Start-Process dnSpy -Args "`"$assembly`" --select T:$type"
+        } elseif (($Decompiler -eq [Decompiler]::ILSpy -or !$Decompiler) -and (Get-Command ILSpy -ErrorAction Ignore)) {
+            Start-Process ILSpy -Args "`"$assembly`" /navigateTo:T:$type"
+        } elseif (($Decompiler -eq [Decompiler]::dotPeek -or !$Decompiler) -and (Get-Command dotPeek -ErrorAction Ignore)) {
+            dotPeek /select=$assembly!$type
+        } elseif (($Decompiler -eq [Decompiler]::JustDecompile -or !$Decompiler) -and (Get-Command JustDecompile -ErrorAction Ignore)) {
+            Start-Process JustDecompile -Args "/target:`"$assembly`""
+        } elseif (($Decompiler -eq [Decompiler]::Reflector -or !$Decompiler) -and (Get-Command reflector -ErrorAction Ignore)) {
+            Start-Process reflector -Args "/select:$type `"$assembly`""
         } elseif ($Decompiler -eq [Decompiler]::GitHub -or !$Decompiler) {
             $class = $commandInfo.ImplementingType.Name
             $uri = "https://api.github.com/search/code?q=`"class+${class}`"+in:file+repo:powershell/powershell"
@@ -96,7 +96,7 @@ function Get-CommandSource {
             $result = Invoke-RestMethod -Uri $uri -Method Get
             if ($result) {
                 $url = $result.items | Select-Object -ExpandProperty html_url
-                Start-Process -FilePath $url
+                Start-Process $url
             }       
         } else {
             throw 'Unable to find decompiler in your path'


### PR DESCRIPTION
I was unable to get Get-CommandSource 'Receive-Job' to launch, and I discovered it was because ILSpy wasn't receiving the path correctly. Because Start-Process doesn't pass arguments as objects, quoting the paths is necessary.

dotPeek32 is just dotPeek these days, so I adjusted that, and I also changed the ErrorActions of Get-Command to Ignore, which keeps it from adding to the $Error variable (I made sure it'd still work as an if condition this way).

Lastly, I trimmed down the Start-Process syntax a little.